### PR TITLE
OpenDark#76: Fix unwanted line below tab bar

### DIFF
--- a/OpenDark/OpenDark.qss
+++ b/OpenDark/OpenDark.qss
@@ -284,7 +284,6 @@ QToolBar {
     margin: 0;
     padding: 0; }
   QToolBar QTabBar::tab {
-    margin-top: -1px;
     padding-top: 6px; }
   QToolBar QPushButton, QToolBar QSint--ActionGroup QFrame[class="content"] QToolButton, QToolBar QSint--ActionGroup QFrame[class="content"] QWidget#Selector > QToolButton, QSint--ActionGroup QFrame[class="content"] QToolBar QToolButton, QSint--ActionGroup QFrame[class="content"] QToolBar QWidget#Selector > QToolButton, QToolBar QWidget#wbList QPushButton, QToolBar QWidget#wbList QSint--ActionGroup QFrame[class="content"] QToolButton, QSint--ActionGroup QFrame[class="content"] QToolBar QWidget#wbList QToolButton, QWidget#wbList QToolBar QPushButton, QWidget#wbList QToolBar QSint--ActionGroup QFrame[class="content"] QToolButton, QSint--ActionGroup QFrame[class="content"] QWidget#wbList QToolBar QToolButton {
     padding: 3px; }
@@ -410,6 +409,9 @@ QWidget#Selector {
 
 SpreadsheetGui--SheetTableView QLineEdit {
   min-width: 186px; }
+
+QTabBar#WbTabBar {
+  qproperty-drawBase: 0; }
 
 QAbstractSpinBox::up-arrow {
   image: url(qss:images_dark-light/light_up_arrow.svg); }

--- a/OpenLight/OpenLight.qss
+++ b/OpenLight/OpenLight.qss
@@ -284,7 +284,6 @@ QToolBar {
     margin: 0;
     padding: 0; }
   QToolBar QTabBar::tab {
-    margin-top: -1px;
     padding-top: 6px; }
   QToolBar QPushButton, QToolBar QSint--ActionGroup QFrame[class="content"] QToolButton, QToolBar QSint--ActionGroup QFrame[class="content"] QWidget#Selector > QToolButton, QSint--ActionGroup QFrame[class="content"] QToolBar QToolButton, QSint--ActionGroup QFrame[class="content"] QToolBar QWidget#Selector > QToolButton, QToolBar QWidget#wbList QPushButton, QToolBar QWidget#wbList QSint--ActionGroup QFrame[class="content"] QToolButton, QSint--ActionGroup QFrame[class="content"] QToolBar QWidget#wbList QToolButton, QWidget#wbList QToolBar QPushButton, QWidget#wbList QToolBar QSint--ActionGroup QFrame[class="content"] QToolButton, QSint--ActionGroup QFrame[class="content"] QWidget#wbList QToolBar QToolButton {
     padding: 3px; }
@@ -410,6 +409,9 @@ QWidget#Selector {
 
 SpreadsheetGui--SheetTableView QLineEdit {
   min-width: 186px; }
+
+QTabBar#WbTabBar {
+  qproperty-drawBase: 0; }
 
 QAbstractSpinBox::up-arrow {
   image: url(qss:images_dark-light/dark_up_arrow.svg); }

--- a/scss/_openStyle.scss
+++ b/scss/_openStyle.scss
@@ -335,7 +335,6 @@ QToolBar {
     }
     QTabBar {
         &::tab { 
-            margin-top: -1px;
             padding-top: 6px;
         }
     }
@@ -506,4 +505,8 @@ QWidget#Selector {
 
 SpreadsheetGui--SheetTableView QLineEdit {
     min-width: 186px;
+}
+
+QTabBar#WbTabBar {
+    qproperty-drawBase: 0;
 }


### PR DESCRIPTION
This fixes issue described in the obelisk79/OpenDark#76.

![image](https://github.com/obelisk79/OpenTheme/assets/747404/2970e81e-6580-4c7f-93e3-8f76749cb823)
