### PR TITLE
Add missing UseBackgroundColorMid=0 parameter to OpenLight

### DIFF
--- a/OpenLight/OpenLight.cfg
+++ b/OpenLight/OpenLight.cfg
@@ -130,10 +130,11 @@
           <FCUInt Name="CursorCrosshairColor" Value="556083711"/>
           <FCUInt Name="CreateLineColor" Value="556083711"/>
           <FCUInt Name="AnnotationTextColor" Value="876232959"/>
-          <FCUInt Name="BackgroundColor" Value="556083711"/>
+          <FCBool Name="UseBackgroundColorMid" Value="0"/>
+          <FCUInt Name="BackgroundColor" Value="3470056191"/>
           <FCUInt Name="BackgroundColor2" Value="4177132287"/>
           <FCUInt Name="BackgroundColor3" Value="3470056191"/>
-          <FCUInt Name="BackgroundColor4" Value="556083711"/>
+          <FCUInt Name="BackgroundColor4" Value="3470056191"/>
           <FCUInt Name="BacklightColor" Value="4059297279"/>
           <FCUInt Name="BoundingBoxColor" Value="1230002175"/>
           <FCUInt Name="DefaultShapeColor" Value="2914369023"/>


### PR DESCRIPTION
also fix dark background colors being set

as discussed on discord this led to weird results if the user had previously enabled the middle background color:
![image](https://github.com/obelisk79/OpenTheme/assets/36372335/ac894ef8-d718-44f0-a35b-457fb4d7f7b4)
