### PR TITLE
Extend preferences dialog selector background

### DIFF
--- a/OpenDark/OpenDark.qss
+++ b/OpenDark/OpenDark.qss
@@ -347,6 +347,15 @@ QDialog#Gui__Dialog__DlgPreferences QListView {
   padding: 10px 5px 10px 20px;
   min-width: 120px; }
 
+QDialog#Gui__Dialog__DlgPreferences QTreeView#groupsTreeView {
+  show-decoration-selected: 1; }
+  QDialog#Gui__Dialog__DlgPreferences QTreeView#groupsTreeView::item {
+    border: none;
+    border-radius: 0;
+    background-color: transparent; }
+    QDialog#Gui__Dialog__DlgPreferences QTreeView#groupsTreeView::item:selected {
+      border: none; }
+
 QToolBar > Gui--WorkbenchComboBox QAbstractItemView {
   min-width: 180px; }
 
@@ -912,3 +921,8 @@ QWidget#Selector > QToolButton {
   QWidget#Selector > QToolButton:hover {
     background-color: #292f35;
     border: 1px solid #264b69; }
+
+QDialog#Gui__Dialog__DlgPreferences QTreeView#groupsTreeView {
+  selection-background-color: #1f364d; }
+  QDialog#Gui__Dialog__DlgPreferences QTreeView#groupsTreeView::item:selected {
+    background-color: #1f364d; }

--- a/OpenLight/OpenLight.qss
+++ b/OpenLight/OpenLight.qss
@@ -347,6 +347,15 @@ QDialog#Gui__Dialog__DlgPreferences QListView {
   padding: 10px 5px 10px 20px;
   min-width: 120px; }
 
+QDialog#Gui__Dialog__DlgPreferences QTreeView#groupsTreeView {
+  show-decoration-selected: 1; }
+  QDialog#Gui__Dialog__DlgPreferences QTreeView#groupsTreeView::item {
+    border: none;
+    border-radius: 0;
+    background-color: transparent; }
+    QDialog#Gui__Dialog__DlgPreferences QTreeView#groupsTreeView::item:selected {
+      border: none; }
+
 QToolBar > Gui--WorkbenchComboBox QAbstractItemView {
   min-width: 180px; }
 
@@ -912,3 +921,8 @@ QWidget#Selector > QToolButton {
   QWidget#Selector > QToolButton:hover {
     background-color: #a3a8ad;
     border: 1px solid #339af0; }
+
+QDialog#Gui__Dialog__DlgPreferences QTreeView#groupsTreeView {
+  selection-background-color: #a5d8ff; }
+  QDialog#Gui__Dialog__DlgPreferences QTreeView#groupsTreeView::item:selected {
+    background-color: #a5d8ff; }

--- a/scss/OpenDark.scss
+++ b/scss/OpenDark.scss
@@ -502,3 +502,11 @@ QWidget#Selector > QToolButton {
         border: 1px solid $accentBorder;
     }
 }
+
+QDialog#Gui__Dialog__DlgPreferences QTreeView#groupsTreeView {
+    selection-background-color: $accentBackground;
+
+    &::item:selected {
+        background-color: $accentBackground;
+    }
+}

--- a/scss/OpenLight.scss
+++ b/scss/OpenLight.scss
@@ -502,3 +502,11 @@ QWidget#Selector > QToolButton {
         border: 1px solid $accentBorder;
     }
 }
+
+QDialog#Gui__Dialog__DlgPreferences QTreeView#groupsTreeView {
+    selection-background-color: $accentBackground;
+
+    &::item:selected {
+        background-color: $accentBackground;
+    }
+}

--- a/scss/_openStyle.scss
+++ b/scss/_openStyle.scss
@@ -421,6 +421,20 @@ QDialog#Gui__Dialog__DlgPreferences QListView {
     padding: 10px 5px 10px 20px;
     min-width: 120px;
 }
+ 
+QDialog#Gui__Dialog__DlgPreferences QTreeView#groupsTreeView {
+    show-decoration-selected: 1;
+
+    &::item {
+        border: none;
+        border-radius: 0;
+        background-color: transparent;
+
+        &:selected {
+            border: none;
+        }
+    }
+}
 
 QToolBar > Gui--WorkbenchComboBox QAbstractItemView {
     min-width: 180px;


### PR DESCRIPTION
This changes behavior of preferences page selector to be more in-line with how it was designed.

![image](https://github.com/obelisk79/OpenTheme/assets/747404/739f9aea-06e7-4b4c-ac42-cf2fdafba43e)

was:

![image](https://github.com/obelisk79/OpenTheme/assets/747404/997189ba-c6e8-4280-99cb-2a089260c52c)

