### PR TITLE
Add more spacing to menu items

### DIFF
--- a/OpenDark/OpenDark.qss
+++ b/OpenDark/OpenDark.qss
@@ -184,11 +184,9 @@ QMenu {
     margin: 0px 10px; }
 
 QMenuBar {
-  padding: 3px 0px 3px 0px; }
+  spacing: 2px; }
   QMenuBar::item {
-    padding: 1px;
-    padding-left: 2px;
-    padding-right: 2px; }
+    padding: 3px 6px; }
   QMenuBar::item:pressed {
     border-radius: 2px; }
   QMenuBar::item:selected {

--- a/OpenLight/OpenLight.qss
+++ b/OpenLight/OpenLight.qss
@@ -184,11 +184,9 @@ QMenu {
     margin: 0px 10px; }
 
 QMenuBar {
-  padding: 3px 0px 3px 0px; }
+  spacing: 2px; }
   QMenuBar::item {
-    padding: 1px;
-    padding-left: 2px;
-    padding-right: 2px; }
+    padding: 3px 6px; }
   QMenuBar::item:pressed {
     border-radius: 2px; }
   QMenuBar::item:selected {

--- a/scss/_openStyle.scss
+++ b/scss/_openStyle.scss
@@ -206,11 +206,9 @@ QMenu {
 } 
 
 QMenuBar {
-    padding: 3px 0px 3px 0px;
+    spacing: 2px;
     &::item {
-        padding: 1px;
-        padding-left: 2px;
-        padding-right: 2px;
+        padding: 3px 6px;
     }
     &::item:pressed {
         border-radius: 2px;

--- a/scss/_openStyle.scss
+++ b/scss/_openStyle.scss
@@ -206,6 +206,7 @@ QMenu {
 } 
 
 QMenuBar {
+    padding 3px 0px;
     spacing: 2px;
     &::item {
         padding: 3px 6px;


### PR DESCRIPTION
This changes how background is applied to highlighted / selected menu bar entries extending the background to height of the menu bar like it usually is.

![image](https://github.com/obelisk79/OpenTheme/assets/747404/a17ee44b-46c6-438d-8aca-36cd2c3bf1fa)

was

![image](https://github.com/obelisk79/OpenTheme/assets/747404/379b56fe-a07e-4d20-9cf0-df2c144df6f4)
