### PR TITLE
Add horizontal padding to buttons

### DIFF
--- a/OpenDark/OpenDark.qss
+++ b/OpenDark/OpenDark.qss
@@ -195,8 +195,7 @@ QMenuBar {
     border-radius: 2px; }
 
 QPushButton, QSint--ActionGroup QFrame[class="content"] QToolButton, QSint--ActionGroup QFrame[class="content"] QWidget#Selector > QToolButton, QWidget#wbList QPushButton, QWidget#wbList QSint--ActionGroup QFrame[class="content"] QToolButton, QSint--ActionGroup QFrame[class="content"] QWidget#wbList QToolButton {
-  min-width: 26px;
-  padding: 4px 4px 4px 4px; }
+  padding: 4px 20px; }
 
 QRadioButton {
   margin: 0px;

--- a/OpenLight/OpenLight.qss
+++ b/OpenLight/OpenLight.qss
@@ -195,8 +195,7 @@ QMenuBar {
     border-radius: 2px; }
 
 QPushButton, QSint--ActionGroup QFrame[class="content"] QToolButton, QSint--ActionGroup QFrame[class="content"] QWidget#Selector > QToolButton, QWidget#wbList QPushButton, QWidget#wbList QSint--ActionGroup QFrame[class="content"] QToolButton, QSint--ActionGroup QFrame[class="content"] QWidget#wbList QToolButton {
-  min-width: 26px;
-  padding: 4px 4px 4px 4px; }
+  padding: 4px 20px; }
 
 QRadioButton {
   margin: 0px;

--- a/scss/_openStyle.scss
+++ b/scss/_openStyle.scss
@@ -221,8 +221,7 @@ QMenuBar {
 }
 
 QPushButton {
-    min-width: 26px;
-    padding: 4px 4px 4px 4px;
+    padding: 4px 20px;
 }
 
 QRadioButton {


### PR DESCRIPTION
This adds more horizontal padding to buttons to not look crammed and squished: https://medium.com/@manonpiette.pro/margins-and-padding-e4e9d0efa65d. This also makes button a lot easier to click. 

![image](https://github.com/obelisk79/OpenTheme/assets/747404/7d025207-f7f4-4c46-a2d2-bb1dcbf3f622)

was:

![image](https://github.com/obelisk79/OpenTheme/assets/747404/8f4535e0-b9d9-45ad-abc5-99869187336e)