### PR TITLE
Add sketcher grid colors to Opendark

### DIFF
--- a/OpenDark/OpenDark.cfg
+++ b/OpenDark/OpenDark.cfg
@@ -150,6 +150,8 @@
             <FCParamGroup Name="General">
               <FCUInt Name="GridLineColor" Value="1230002175"/>
               <FCUInt Name="GridDivLineColor" Value="1230002175"/>
+              <FCInt Name="GridDivLinePattern" Value="65535"/>
+              <FCInt Name="GridLinePattern" Value="43690"/>
             </FCParamGroup>
         </FCParamGroup>
         <FCParamGroup Name="TreeView">

--- a/OpenDark/OpenDark.cfg
+++ b/OpenDark/OpenDark.cfg
@@ -146,6 +146,11 @@
           <FCParamGroup Name="Spreadsheet">
             <FCText Name="AliasedCellBackgroundColor">#495057</FCText>
           </FCParamGroup>
+          <FCParamGroup Name="Sketcher">
+            <FCParamGroup Name="General">
+              <FCUInt Name="GridLineColor" Value="1230002175"/>
+              <FCUInt Name="GridDivLineColor" Value="1230002175"/>
+            </FCParamGroup>
         </FCParamGroup>
         <FCParamGroup Name="TreeView">
           <FCUInt Name="TreeEditColor" Value="1434171135"/>

--- a/OpenLight/OpenLight.cfg
+++ b/OpenLight/OpenLight.cfg
@@ -82,8 +82,6 @@
             <FCParamGroup Name="General">
               <FCUInt Name="GridLineColor" Value="3082800383"/>
               <FCUInt Name="GridDivLineColor" Value="3082800383"/>
-              <FCInt Name="ConstraintFilterState" Value="33546244"/>
-              <FCInt Name="GridLinePattern" Value="43690"/>
             </FCParamGroup>
             <FCParamGroup Name="View">
               <FCInt Name="EdgeWidth" Value="3"/>

--- a/OpenLight/OpenLight.cfg
+++ b/OpenLight/OpenLight.cfg
@@ -82,6 +82,8 @@
             <FCParamGroup Name="General">
               <FCUInt Name="GridLineColor" Value="3082800383"/>
               <FCUInt Name="GridDivLineColor" Value="3082800383"/>
+              <FCInt Name="GridDivLinePattern" Value="65535"/>
+              <FCInt Name="GridLinePattern" Value="43690"/>
             </FCParamGroup>
             <FCParamGroup Name="View">
               <FCInt Name="EdgeWidth" Value="3"/>


### PR DESCRIPTION
I used the same color that was used for the Draft grid

I also removed a couple of IMO unnecessary preferences from OpenLight, there is no reason to set the constraint filter state in a theme and it seemed inconsistent to set the gridpattern in openlight but not opendark, and to set only the major line patter and not the subdivision line pattern. The alternative would be to set both patterns on both themes