### PR TITLE
Add missing CbLabelColor to OpenDark

### DIFF
--- a/OpenDark/OpenDark.cfg
+++ b/OpenDark/OpenDark.cfg
@@ -54,6 +54,7 @@
           <FCUInt Name="DefaultShapeColor" Value="1920565503"/>
           <FCUInt Name="HighlightColor" Value="424507647"/>
           <FCUInt Name="SelectionColor" Value="543173631"/>
+          <FCUInt Name="CbLabelColor" Value="2914369023"/>
         </FCParamGroup>
         <FCParamGroup Name="Editor">
           <FCUInt Name="Text" Value="3570717696"/>


### PR DESCRIPTION
I used same color as `AnnotationTextColor`

this fixes an issue where after having enabled openlight and going back to opendark `CbLabelColor` is set to a dark color, making it unreadable with the dark background:
![image](https://github.com/obelisk79/OpenTheme/assets/36372335/b5504217-328c-4889-965f-e54017e39566)

with this change:
![image](https://github.com/obelisk79/OpenTheme/assets/36372335/237410dd-3c1c-4991-8b0c-7745adc181ef)
