### PR TITLE
Fix missing line in OpenDark.cfg from #20

### DIFF
--- a/OpenDark/OpenDark.cfg
+++ b/OpenDark/OpenDark.cfg
@@ -154,6 +154,7 @@
               <FCInt Name="GridDivLinePattern" Value="65535"/>
               <FCInt Name="GridLinePattern" Value="43690"/>
             </FCParamGroup>
+          </FCParamGroup>
         </FCParamGroup>
         <FCParamGroup Name="TreeView">
           <FCUInt Name="TreeEditColor" Value="1434171135"/>


### PR DESCRIPTION
@obelisk79 I missed this line in the sketcher grid PR, xml is pain 🫠

this broke the theme because the xml was invalid