### PR TITLE
 Remove negative margins from QGroupBox 

### DIFF
--- a/OpenDark/OpenDark.qss
+++ b/OpenDark/OpenDark.qss
@@ -94,19 +94,12 @@ QDialog {
 
 QGroupBox {
   font-weight: bold;
-  margin: 10px;
-  padding-top: 10px;
-  margin-left: -20px;
-  margin-right: -20px; }
+  margin-top: 4px;
+  padding-top: 10px; }
   QGroupBox::title {
-    top: -10px;
-    margin-bottom: 4px;
-    margin-left: 16px;
     subcontrol-position: top left;
-    padding-left: 4px;
-    padding-right: 12px;
-    padding-top: 2px;
-    padding-bottom: 2px; }
+    top: -8px;
+    padding-right: 12px; }
   QGroupBox::indicator {
     width: 12px;
     height: 12px;
@@ -340,7 +333,6 @@ QDialog#Gui__Dialog__DlgPreferences QGroupBox {
   border-bottom: 0px; }
 
 QDialog#Gui__Dialog__DlgPreferences QListView {
-  padding: 10px 5px 10px 20px;
   min-width: 120px; }
 
 QDialog#Gui__Dialog__DlgPreferences QTreeView#groupsTreeView {
@@ -602,9 +594,9 @@ QDialog {
   border-radius: 2px; }
 
 QGroupBox {
-  border: 3px solid #495057; }
+  border-top: 3px solid #495057; }
   QGroupBox::indicator {
-    border: 1px solid #495057; }
+    border-top: 1px solid #495057; }
 
 QHeaderView::section {
   background-color: #292f35;

--- a/OpenLight/OpenLight.qss
+++ b/OpenLight/OpenLight.qss
@@ -94,19 +94,12 @@ QDialog {
 
 QGroupBox {
   font-weight: bold;
-  margin: 10px;
-  padding-top: 10px;
-  margin-left: -20px;
-  margin-right: -20px; }
+  margin-top: 4px;
+  padding-top: 10px; }
   QGroupBox::title {
-    top: -10px;
-    margin-bottom: 4px;
-    margin-left: 16px;
     subcontrol-position: top left;
-    padding-left: 4px;
-    padding-right: 12px;
-    padding-top: 2px;
-    padding-bottom: 2px; }
+    top: -8px;
+    padding-right: 12px; }
   QGroupBox::indicator {
     width: 12px;
     height: 12px;
@@ -340,7 +333,6 @@ QDialog#Gui__Dialog__DlgPreferences QGroupBox {
   border-bottom: 0px; }
 
 QDialog#Gui__Dialog__DlgPreferences QListView {
-  padding: 10px 5px 10px 20px;
   min-width: 120px; }
 
 QDialog#Gui__Dialog__DlgPreferences QTreeView#groupsTreeView {
@@ -602,9 +594,9 @@ QDialog {
   border-radius: 2px; }
 
 QGroupBox {
-  border: 3px solid #868e96; }
+  border-top: 3px solid #868e96; }
   QGroupBox::indicator {
-    border: 1px solid #868e96; }
+    border-top: 1px solid #868e96; }
 
 QHeaderView::section {
   background-color: #a3a8ad;

--- a/scss/OpenDark.scss
+++ b/scss/OpenDark.scss
@@ -89,9 +89,9 @@ QDialog {
 
 // non-interactive element
 QGroupBox {
-    border: 3px solid $contrastBorder;
+    border-top: 3px solid $contrastBorder;
     &::indicator {
-        border: 1px solid $contrastBorder;
+        border-top: 1px solid $contrastBorder;
     }
 }
 

--- a/scss/OpenLight.scss
+++ b/scss/OpenLight.scss
@@ -487,3 +487,11 @@ QWidget#Selector > QToolButton {
         border: 1px solid $accentBorder;
     }
 }
+
+QDialog#Gui__Dialog__DlgPreferences QTreeView#groupsTreeView {
+    selection-background-color: $accentBackground;
+
+    &::item:selected {
+        background-color: $accentBackground;
+    }
+}

--- a/scss/OpenLight.scss
+++ b/scss/OpenLight.scss
@@ -89,9 +89,9 @@ QDialog {
 
 // non-interactive element
 QGroupBox {
-    border: 3px solid $contrastBorder;
+    border-top: 3px solid $contrastBorder;
     &::indicator {
-        border: 1px solid $contrastBorder;
+        border-top: 1px solid $contrastBorder;
     }
 }
 

--- a/scss/_openStyle.scss
+++ b/scss/_openStyle.scss
@@ -90,20 +90,15 @@ QDialog {
 // non-interactive element
 QGroupBox {
     font-weight: bold;
-    margin: 10px;
+    margin-top: 4px;
     padding-top: 10px;
-    margin-left: -20px;
-    margin-right: -20px;
+
     &::title {
-            top: -10px;
-            margin-bottom: 4px;
-            margin-left: 16px;
-            subcontrol-position: top left;
-            padding-left: 4px;
-            padding-right: 12px;
-            padding-top: 2px;
-            padding-bottom: 2px;
+        subcontrol-position: top left;
+        top: -8px;
+        padding-right: 12px;
     }
+
     &::indicator {
         width: 12px;
         height: 12px;
@@ -416,7 +411,6 @@ QDialog#Gui__Dialog__DlgPreferences QGroupBox {
 }
 
 QDialog#Gui__Dialog__DlgPreferences QListView {
-    padding: 10px 5px 10px 20px;
     min-width: 120px;
 }
  


### PR DESCRIPTION
This fixes issues with word wrapped labels and unnecessary scrollbars that are not correctly calculated due to negative margins used in the qss.

After:
![image](https://github.com/obelisk79/OpenTheme/assets/747404/71c030fa-ff50-4543-8ca0-3a392aacc8bf)
 
Before:
![image](https://github.com/obelisk79/OpenTheme/assets/747404/c82add0d-416c-4a2a-b4a6-452bbee0193d)
