### PR TITLE
Remove bottom border and background from toolbars in custom areas

### DIFF
--- a/OpenDark/OpenDark.qss
+++ b/OpenDark/OpenDark.qss
@@ -286,6 +286,13 @@ QToolBar {
 QToolBarExtension {
   min-width: 16px; }
 
+QStatusBar QToolBar, QMenuBar QToolBar {
+  background-color: transparent;
+  border-bottom: none; }
+
+Gui--ToolBarAreaWidget {
+  background-color: transparent; }
+
 QToolButton, QWidget#Selector > QToolButton {
   margin: 0px 3px 0px 3px;
   padding: 2px;

--- a/OpenLight/OpenLight.qss
+++ b/OpenLight/OpenLight.qss
@@ -286,6 +286,13 @@ QToolBar {
 QToolBarExtension {
   min-width: 16px; }
 
+QStatusBar QToolBar, QMenuBar QToolBar {
+  background-color: transparent;
+  border-bottom: none; }
+
+Gui--ToolBarAreaWidget {
+  background-color: transparent; }
+
 QToolButton, QWidget#Selector > QToolButton {
   margin: 0px 3px 0px 3px;
   padding: 2px;

--- a/scss/_openStyle.scss
+++ b/scss/_openStyle.scss
@@ -349,6 +349,16 @@ QToolBarExtension {
     min-width: 16px;
 }
 
+// special case for toolbars placed in menu bar and status bar
+QStatusBar QToolBar, QMenuBar QToolBar {
+    background-color: transparent;
+    border-bottom: none;
+}
+
+Gui--ToolBarAreaWidget {
+    background-color: transparent;
+}
+
 QToolButton {
     margin: 0px 3px 0px 3px;
     padding: 2px;


### PR DESCRIPTION
This ensures that custom toolbar areas do not display unnecessary background:

before:
![image](https://github.com/obelisk79/OpenTheme/assets/747404/b73db5b0-dbe4-4c7c-b1e1-7a3ff3a94f58)

after:
![image](https://github.com/obelisk79/OpenTheme/assets/747404/68b2f434-ed16-4df3-bb5c-626dffca6628)
