### PR TITLE
Remove background from overlay tabs

### DIFF
--- a/OpenLight/overlay/OpenLight_Overlay.qss
+++ b/OpenLight/overlay/OpenLight_Overlay.qss
@@ -6,6 +6,8 @@
 QTabWidget::pane {
   background-color: transparent;
   border: transparent; }
+  QTabWidget::pane QTabBar {
+    background-color: transparent; }
 
 /* The OverlayTabWidget is named as OverlayLeft, OverlayRight, OverlayTop, OverlayBottom.
   To customize for each overlay docking site, use the following selector

--- a/scss/OpenDark_Overlay.scss
+++ b/scss/OpenDark_Overlay.scss
@@ -9,6 +9,10 @@
   QTabWidget::pane {
     background-color: transparent;
     border: transparent;
+
+    QTabBar {
+      background-color: transparent;
+    }
   }
   
   /* The OverlayTabWidget is named as OverlayLeft, OverlayRight, OverlayTop, OverlayBottom.

--- a/scss/OpenLight_Overlay.scss
+++ b/scss/OpenLight_Overlay.scss
@@ -10,6 +10,10 @@
   QTabWidget::pane {
     background-color: transparent;
     border: transparent;
+
+    QTabBar {
+      background-color: transparent;
+    }
   }
   
   /* The OverlayTabWidget is named as OverlayLeft, OverlayRight, OverlayTop, OverlayBottom.


### PR DESCRIPTION
Remove background from tabs in overlay:

before:
![image](https://github.com/obelisk79/OpenTheme/assets/747404/04e4c791-9eba-4f79-abe8-c62a8f1135e9)

after:
![image](https://github.com/obelisk79/OpenTheme/assets/747404/3adc23e0-a411-4482-865b-e36cc82aa4c1)
