### PR TITLE
Remove border-radius from toolbars

### DIFF
--- a/OpenDark/OpenDark.qss
+++ b/OpenDark/OpenDark.qss
@@ -268,7 +268,8 @@ QTreeView QLineEdit {
   margin: 0px; }
 
 QToolBar {
-  padding: 2px; }
+  padding: 2px;
+  border-radius: 0; }
   QToolBar * {
     margin: 0;
     padding: 0; }

--- a/OpenLight/OpenLight.qss
+++ b/OpenLight/OpenLight.qss
@@ -268,7 +268,8 @@ QTreeView QLineEdit {
   margin: 0px; }
 
 QToolBar {
-  padding: 2px; }
+  padding: 2px;
+  border-radius: 0; }
   QToolBar * {
     margin: 0;
     padding: 0; }

--- a/scss/_openStyle.scss
+++ b/scss/_openStyle.scss
@@ -321,6 +321,7 @@ QTreeView QLineEdit {
 
 QToolBar {
     padding: 2px;
+    border-radius: 0;
     * {
         margin: 0;
         padding: 0;


### PR DESCRIPTION
Before:
![image](https://github.com/obelisk79/OpenTheme/assets/747404/ba2b5475-d975-4754-a249-180fbff2c4bd)

After:
![image](https://github.com/obelisk79/OpenTheme/assets/747404/38217bdd-f737-4e80-b313-f98bcd375e85)

Fixes: #70 