### PR TITLE
OpenPreferences: Remove parameters that match the default config

### DIFF
--- a/OpenPreferences/OpenPreferences.cfg
+++ b/OpenPreferences/OpenPreferences.cfg
@@ -101,6 +101,10 @@
             <FCInt Name="Width" Value="381"/>
             <FCText Name="Widgets">Tasks,</FCText>
             <FCBool Name="Transparent" Value="1"/>
+            <FCBool Name="AutoHide" Value="0"/>
+            <FCBool Name="EditShow" Value="0"/>
+            <FCBool Name="EditHide" Value="0"/>
+            <FCBool Name="TaskShow" Value="0"/>
           </FCParamGroup>
           <FCBool Name="Std_TaskView" Value="0"/>
           <FCBool Name="Std_TreeView" Value="0"/>


### PR DESCRIPTION
I wanted to better understand the changes being made by this preference pack. I created this update by comparing it to a fresh `user.cfg` where I opened each workbench and also saved the preferences.

This might not be the way you want to maintain your changes but I'm sharing it in case it helps.

I didn't remove it from the `BackgroundAutoloadModules` but after applying your OpenPreferences, the `BIMWorkbench` shows a popup message. Just in case you aren't aware.